### PR TITLE
chore: Updating from debian:stretch to debian:buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 
 # Certificates needed for https requests, to avoid
 # "x509: failed to load system roots and no roots provided" error.


### PR DESCRIPTION
chore: Bump Dockerfile version from `debian:stretch` to `debian:buster`.

Debian Long Term Support [1] states that stretch's support ended June 30, 2022.
We were still able to perform Docker builds even while not supported. Recently,
patch files for stretch have gone missing from Debian, so we cannot use this
anymore.

Bump to the next LTS version (buster) to have builds working once again.

Auto-assigned to @mcab to merge if builds pass, and to engage with the team
that owns the repo in order to get working.

[1] https://wiki.debian.org/LTS